### PR TITLE
Remove unused logger from AgentHistoryCalculator

### DIFF
--- a/src/Vectra.Infrastructure/Risk/Calculators/AgentHistoryCalculator.cs
+++ b/src/Vectra.Infrastructure/Risk/Calculators/AgentHistoryCalculator.cs
@@ -11,12 +11,9 @@ public class AgentHistoryCalculator : IRiskCalculator
     public double Weight { get; set; } = 0.35;
 
     private readonly IAgentHistoryRepository _historyRepo;
-    private readonly ILogger<AgentHistoryCalculator> _logger;
-
-    public AgentHistoryCalculator(IAgentHistoryRepository historyRepo, ILogger<AgentHistoryCalculator> logger)
+    public AgentHistoryCalculator(IAgentHistoryRepository historyRepo)
     {
         _historyRepo = historyRepo;
-        _logger = logger;
     }
 
     public async Task<double> CalculateAsync(RequestContext context, AgentHistory? history, CancellationToken ct)


### PR DESCRIPTION
This removes the unused logger dependency from `AgentHistoryCalculator`, matching the current implementation so the constructor only receives the history repository it actually uses. It also drops the unused private field assignment referenced in #144.

Verification: `dotnet restore && dotnet build --no-restore` was run locally; the build did not complete successfully in this environment.