### PR TITLE
fix: add default value to CancellationToken in AssignPolicyHandler.Ha…

### DIFF
--- a/src/Vectra.Application/Features/Agents/AssignPolicy/AssignPolicyHandler.cs
+++ b/src/Vectra.Application/Features/Agents/AssignPolicy/AssignPolicyHandler.cs
@@ -24,7 +24,7 @@ internal class AssignPolicyHandler : IActionHandler<AssignPolicyRequest, Result<
         _policyLoader = policyLoader ?? throw new ArgumentNullException(nameof(policyLoader));
     }
 
-    public async Task<Result<Abstractions.Dispatchers.Void>> Handle(AssignPolicyRequest request, CancellationToken cancellationToken)
+    public async Task<Result<Abstractions.Dispatchers.Void>> Handle(AssignPolicyRequest request, CancellationToken cancellationToken = default)
     {
         var agentId = Guid.Parse(request.AgentId);
         var agent = await _agentRepository.GetByIdAsync(agentId, cancellationToken);


### PR DESCRIPTION
## Summary

Adds the missing `= default` value to the `CancellationToken` parameter in the overridden `Handle` method of `AssignPolicyHandler`.

## Issue reference

Closes #233

## What type of PR is this?

- [x] Bug Fix
- [x] Refactor

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The change is minimal and isolated to the reported issue