### PR TITLE
Refactor: Rename requestBody to match interface in AnalyzeAsync

### DIFF
--- a/src/Vectra.Infrastructure/Semantic/Providers/InternalBert/InternalOnnxProvider.cs
+++ b/src/Vectra.Infrastructure/Semantic/Providers/InternalBert/InternalOnnxProvider.cs
@@ -56,22 +56,22 @@ public sealed class InternalOnnxProvider : ISemanticProvider, IDisposable
     }
 
     public async Task<SemanticAnalysisResult> AnalyzeAsync(
-        string? requestBody,
+        string? body,
         string metadata,
         CancellationToken cancellationToken)
     {
         if (!_enabled)
             return new SemanticAnalysisResult { Intent = "unknown", Confidence = 0.5, FallbackSafe = true };
 
-        if (string.IsNullOrWhiteSpace(requestBody))
+        if (string.IsNullOrWhiteSpace(body))
             return new SemanticAnalysisResult { Intent = "unknown", Confidence = 0.5, FallbackSafe = true };
 
-        var cacheKey = $"semantic_internal:{ComputeHash(requestBody)}";
+        var cacheKey = $"semantic_internal:{ComputeHash(body)}";
         var (success, cached) = await _cacheProvider!.TryGetValueAsync<SemanticAnalysisResult>(cacheKey);
         if (success)
             return cached!;
 
-        var (inputIds, attentionMask) = _tokenizer!.Tokenize(requestBody, _maxLength);
+        var (inputIds, attentionMask) = _tokenizer!.Tokenize(body, _maxLength);
         var inputTensor = new DenseTensor<long>(inputIds, new[] { 1, _maxLength });
         var maskTensor  = new DenseTensor<long>(attentionMask, new[] { 1, _maxLength });
 


### PR DESCRIPTION
… interface

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Renamed the `requestBody` parameter to `body` in the `AnalyzeAsync` implementation within `InternalOnnxProvider.cs` to guarantee consistency with the interface definition.

## Issue reference

Closes #249

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in cortexiumlabs/docs#<issue-number>
* [ ] Specification has been updated / Created issue in cortexiumlabs/docs#<issue-number>
* [ ] Provided sample for the feature / Created issue in cortexiumlabs/docs#<issue-number>