### PR TITLE
fix: rename requestBody to body in AnalyzeAsync (AzureAiProvider)

### DIFF
--- a/src/Vectra.Infrastructure/Semantic/Providers/AzureAi/AzureAiProvider.cs
+++ b/src/Vectra.Infrastructure/Semantic/Providers/AzureAi/AzureAiProvider.cs
@@ -31,12 +31,12 @@ public class AzureAiProvider : SemanticProviderBase, ISemanticProvider
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<SemanticAnalysisResult> AnalyzeAsync(string? requestBody, string metadata, CancellationToken cancellationToken = default)
+    public async Task<SemanticAnalysisResult> AnalyzeAsync(string? body, string metadata, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(requestBody))
+        if (string.IsNullOrWhiteSpace(body))
             return new SemanticAnalysisResult { Intent = "unknown", Confidence = 0.5, FallbackSafe = true };
 
-        var cacheKey = $"semantic_azureai:{ComputeHash(requestBody)}";
+        var cacheKey = $"semantic_azureai:{ComputeHash(body)}";
         var (success, cached) = await _cacheProvider.TryGetValueAsync<SemanticAnalysisResult>(cacheKey);
         if (success)
             return cached!;
@@ -49,7 +49,7 @@ public class AzureAiProvider : SemanticProviderBase, ISemanticProvider
             Messages =
             {
                 new ChatRequestSystemMessage(SystemPrompt),
-                new ChatRequestUserMessage($"Metadata: {metadata}\n\nRequest body:\n{requestBody}")
+                new ChatRequestUserMessage($"Metadata: {metadata}\n\nRequest body:\n{body}")
             }
         };
 
@@ -70,4 +70,4 @@ public class AzureAiProvider : SemanticProviderBase, ISemanticProvider
         return result;
     }
 
-    }
+}


### PR DESCRIPTION
Closes #251
Renamed `requestBody` parameter to `body` in `AnalyzeAsync` to match interface declaration.