### PR TITLE
fix(semantic): rename requestBody to body in OpenAiProvider

### DIFF
--- a/src/Vectra.Infrastructure/Semantic/Providers/OpenAi/OpenAiProvider.cs
+++ b/src/Vectra.Infrastructure/Semantic/Providers/OpenAi/OpenAiProvider.cs
@@ -30,12 +30,12 @@ public class OpenAiProvider : SemanticProviderBase, ISemanticProvider
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<SemanticAnalysisResult> AnalyzeAsync(string? requestBody, string metadata, CancellationToken cancellationToken = default)
+    public async Task<SemanticAnalysisResult> AnalyzeAsync(string? body, string metadata, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(requestBody))
+        if (string.IsNullOrWhiteSpace(body))
             return new SemanticAnalysisResult { Intent = "unknown", Confidence = 0.5, FallbackSafe = true };
 
-        var cacheKey = $"semantic_openai:{ComputeHash(requestBody)}";
+        var cacheKey = $"semantic_openai:{ComputeHash(body)}";
         var (success, cached) = await _cacheProvider.TryGetValueAsync<SemanticAnalysisResult>(cacheKey);
         if (success)
             return cached!;
@@ -43,7 +43,7 @@ public class OpenAiProvider : SemanticProviderBase, ISemanticProvider
         var messages = new List<ChatMessage>
         {
             new SystemChatMessage(SystemPrompt),
-            new UserChatMessage($"Metadata: {metadata}\n\nRequest body:\n{requestBody}")
+            new UserChatMessage($"Metadata: {metadata}\n\nRequest body:\n{body}")
         };
 
         var requestOptions = new ChatCompletionOptions


### PR DESCRIPTION
## Summary
Rename `requestBody` to `body` in `OpenAiProvider.AnalyzeAsync` to match `ISemanticProvider`.

## Related issue
Fixes #247