### PR TITLE
fix(agents): add default CancellationToken in AgentsListHandler

### DIFF
--- a/src/Vectra.Application/Features/Agents/AgentsList/AgentsListHandler.cs
+++ b/src/Vectra.Application/Features/Agents/AgentsList/AgentsListHandler.cs
@@ -20,7 +20,7 @@ internal class AgentsListHandler : IActionHandler<AgentsListRequest, PaginatedRe
         _agentRepository = agentRepository ?? throw new ArgumentNullException(nameof(agentRepository));
     }
 
-    public async Task<PaginatedResult<AgentsListResult>> Handle(AgentsListRequest request, CancellationToken cancellationToken)
+    public async Task<PaginatedResult<AgentsListResult>> Handle(AgentsListRequest request, CancellationToken cancellationToken = default)
     {
         try
         {


### PR DESCRIPTION
## Summary
Add `= default` to `CancellationToken` in `AgentsListHandler.Handle` to match the interface/base signature.

## Related issue
Fixes #231