### PR TITLE
fix: add default CancellationToken to remaining handlers

### DIFF
--- a/src/Vectra.Application/Features/Agents/RegisterAgent/CreateAgentHandler.cs
+++ b/src/Vectra.Application/Features/Agents/RegisterAgent/CreateAgentHandler.cs
@@ -23,7 +23,7 @@ internal class CreateAgentHandler : IActionHandler<CreateAgentRequest, Result<Cr
         _secretHasher = secretHasher ?? throw new ArgumentNullException(nameof(secretHasher));
     }
 
-    public async Task<Result<CreateAgentResult>> Handle(CreateAgentRequest request, CancellationToken cancellationToken)
+    public async Task<Result<CreateAgentResult>> Handle(CreateAgentRequest request, CancellationToken cancellationToken = default)
     {
         var clientSecretHash = _secretHasher.HashPassword(request.ClientSecret);
         var agent = new Agent(request.Name, request.OwnerId, clientSecretHash);

--- a/src/Vectra.Application/Features/Authentications/GenerateToken/GenerateTokenHandler.cs
+++ b/src/Vectra.Application/Features/Authentications/GenerateToken/GenerateTokenHandler.cs
@@ -29,7 +29,7 @@ internal class GenerateTokenHandler : IActionHandler<GenerateTokenRequest, Resul
         _secretHasher = secretHasher ?? throw new ArgumentNullException(nameof(secretHasher));
     }
 
-    public async Task<Result<GenerateTokenResult>> Handle(GenerateTokenRequest request, CancellationToken cancellationToken)
+    public async Task<Result<GenerateTokenResult>> Handle(GenerateTokenRequest request, CancellationToken cancellationToken = default)
     {
         var agent = await _agentRepository.GetByIdAsync(request.AgentId, cancellationToken);
         if (agent == null || agent.Status != AgentStatus.Active)

--- a/src/Vectra.Application/Features/Policies/PoliciesList/PoliciesListHandler.cs
+++ b/src/Vectra.Application/Features/Policies/PoliciesList/PoliciesListHandler.cs
@@ -13,7 +13,7 @@ internal class PoliciesListHandler : IActionHandler<PoliciesListRequest, Paginat
         _policyCacheService = policyCacheService ?? throw new ArgumentNullException(nameof(policyCacheService));
     }
 
-    public async Task<PaginatedResult<PoliciesListResult>> Handle(PoliciesListRequest request, CancellationToken cancellationToken)
+    public async Task<PaginatedResult<PoliciesListResult>> Handle(PoliciesListRequest request, CancellationToken cancellationToken = default)
     {
         var (policies, totalCount) = await _policyCacheService.GetPagedAsync(request.Page, request.PageSize, cancellationToken);
 

--- a/src/Vectra.Application/Features/Policies/PolicyDetails/PolicyDetailsHandler.cs
+++ b/src/Vectra.Application/Features/Policies/PolicyDetails/PolicyDetailsHandler.cs
@@ -20,7 +20,7 @@ internal class PolicyDetailsHandler : IActionHandler<PolicyDetailsRequest, Resul
         _policyCacheService = policyCacheService ?? throw new ArgumentNullException(nameof(policyCacheService));
     }
 
-    public async Task<Result<PolicyDetailsResult>> Handle(PolicyDetailsRequest request, CancellationToken cancellationToken)
+    public async Task<Result<PolicyDetailsResult>> Handle(PolicyDetailsRequest request, CancellationToken cancellationToken = default)
     {
         var (policies, _) = await _policyCacheService.GetPagedAsync(1, int.MaxValue, cancellationToken);
 


### PR DESCRIPTION
## Summary
Add `= default` to `CancellationToken` in four handlers that were still missing it.

## Related issue
Part of #231